### PR TITLE
href に / がないと現在のパスからの相対パスになってしまうので修正

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -11,19 +11,19 @@ const LINKS = [
     label: "Home",
   },
   {
-    href: "01-client-server",
+    href: "/01-client-server",
     label: "01-client-server",
   },
   {
-    href: "02-routing",
+    href: "/02-routing",
     label: "02-routing",
   },
   {
-    href: "03-server-actions",
+    href: "/03-server-actions",
     label: "03-server-actions",
   },
   {
-    href: "04-cache",
+    href: "/04-cache",
     label: "04-cache",
   },
 ];


### PR DESCRIPTION
モブ中に見つけました